### PR TITLE
jcs-7: Fixed potential security breach in the HTMLRenderer class.

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,25 @@
+name: .NET
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/Example.Api/Controllers/CrudController.cs
+++ b/Example.Api/Controllers/CrudController.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Example.Api.Model;
+using Example.Api.Views.App;
+using JeyDotC.JustCs;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Example.Api.Controllers
+{
+    [Route("[controller]")]
+    public class CrudController : Controller
+    {
+        public IView Index()
+        {
+            return new View<DataList>(new DataListProps
+            {
+                Results = new Data[] { }
+            });
+        }
+    }
+}

--- a/Example.Api/Example.Api.csproj
+++ b/Example.Api/Example.Api.csproj
@@ -11,6 +11,7 @@
     <None Remove="Views\App\" />
     <None Remove="Views\Components\" />
     <None Remove="Model\" />
+    <None Remove="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Views\" />
@@ -23,5 +24,8 @@
     <ProjectReference Include="..\JeyDotC.JustCs.Mvc\JeyDotC.JustCs.Mvc.csproj">
       <GlobalPropertiesToRemove></GlobalPropertiesToRemove>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
   </ItemGroup>
 </Project>

--- a/JeyDotC.JustCs.Tests/HtmlRendererTests.cs
+++ b/JeyDotC.JustCs.Tests/HtmlRendererTests.cs
@@ -575,5 +575,23 @@ namespace JeyDotC.JustCs.Tests
             Assert.Equal("<div data-some-value=\"value\" id=\"my-id\" aria-hidden=\"false\" nonce=\"some-value\" arbitrary-value=\"arbitrary\"></div>\n", result);
 
         }
+
+        class MaliciousElement : Element
+        {
+            public override string Tag => "malicious /> <script>alert('evil!');</script> <malicious";
+        }
+
+        [Fact]
+        public void RenderAsHtml_ShouldThrowOnInvalidTagNames()
+        {
+            // Arrange
+            var maliciousElement = new MaliciousElement { };
+
+            // Act
+            Action action = () => maliciousElement.RenderAsHtml();
+
+            // Assert
+            Assert.Throws<InvalidOperationException>(action);
+        }
     }
 }

--- a/JeyDotC.JustCs/Html/TextElement.cs
+++ b/JeyDotC.JustCs/Html/TextElement.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 namespace JeyDotC.JustCs.Html
 {
-    public class TextElement : Element
+    public sealed class TextElement : Element
     {
         private readonly string _data;
 

--- a/JeyDotC.JustCs/HtmlRenderer.cs
+++ b/JeyDotC.JustCs/HtmlRenderer.cs
@@ -2,12 +2,15 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using JeyDotC.JustCs.Html;
 
 namespace JeyDotC.JustCs
 {
     public static class HtmlRenderer
     {
+        private static readonly Regex _tagNameCheck = new Regex("^[A-Za-z]([A-Za-z0-9-]*[A-Za-z0-9])?$", RegexOptions.IgnoreCase);
+
         public static Element RenderAsElement(this ComponentElement component)
             => component.ToElement();
 
@@ -50,6 +53,11 @@ namespace JeyDotC.JustCs
             {
                 RenderChildren(node.Children, builder);
                 return;
+            }
+            
+            if (!_tagNameCheck.IsMatch(node.Tag))
+            {
+                throw new InvalidOperationException($"Invalid HTML tag name '{node.Tag}'");
             }
 
             builder.Append($"<{node.Tag}");

--- a/JeyDotC.JustCs/JeyDotC.JustCs.csproj
+++ b/JeyDotC.JustCs/JeyDotC.JustCs.csproj
@@ -18,6 +18,7 @@ V1.0.2 Switched Attrs and AriaAttrs from class to record.
 V1.0.1 Added support for WAI ARIA attributes.</PackageReleaseNotes>
     <Summary>Library to render HTML using just C#</Summary>
     <PackageTags>HTML, Razor Alternative, React-Inspired</PackageTags>
+    <PackageReadmeFile>../README.md</PackageReadmeFile>
     <Title>JustCs</Title>
   </PropertyGroup>
 


### PR DESCRIPTION
* Custom HTML element classes cannot have arbitrary strings as tags.
* TextElement is now sealed.